### PR TITLE
Update data volume path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository contains a minimal Docker Compose configuration for running [Alb
 3. Start the services with `docker compose up -d`.
 4. Caddy will automatically obtain HTTPS certificates and forward traffic to the Alby Hub container.
 
-Application data is stored in the `albyhub-data` directory. Caddy stores its configuration and certificates in `caddy/data` and `caddy/config`.
+Application data is stored in the `../albyhub` directory (relative to this repository). Caddy stores its configuration and certificates in `caddy/data` and `caddy/config`.
 ## Managing Services
 
 Start the containers in the background with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: albyhub
     env_file: .env
     volumes:
-      - ./albyhub-data:/data
+      - ../albyhub:/data
     expose:             # internal only - no public port needed
       - "8080"
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- update README to point to `../albyhub`
- adjust docker-compose volume path

## Testing
- `docker compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877471ab0808333ba655543ca0bfe5e