### PR TITLE
Add BOLTCipher reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,15 @@ Follow logs in real time:
 podman compose logs -f
 ```
 
+## BOLTCipher
+
+BOLTCipher is an additional service that currently runs outside of the Compose environment. Start it on the host so that it listens on port `8080`. The Caddy proxy forwards `https://boltcipher.f418.me` to this local service via `host.docker.internal:8080`. No container configuration is required at this time.
+
+ 
 
 ## File Overview
 
 - `docker-compose.yml` – Compose file compatible with Podman Compose (and Docker Compose) defining the Alby Hub, website and Caddy services.
-- `caddy/Caddyfile` – Caddy configuration for the reverse proxy to `albyhub.f418.me` and `f418.me`.
+- `caddy/Caddyfile` – Caddy configuration for the reverse proxy to `albyhub.f418.me`, `f418.me` and `boltcipher.f418.me`.
 - `.env-example` – environment variables example file.
 

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -20,3 +20,16 @@ f418.me {
     }
 }
 
+boltcipher.f418.me {
+    # BOLTCipher runs outside of the compose setup on the host. We forward
+    # requests to the host's port 8080.
+    reverse_proxy host.docker.internal:8080
+
+    # Compression and basic security headers
+    encode gzip
+    header {
+        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+        X-Content-Type-Options    "nosniff"
+    }
+}
+


### PR DESCRIPTION
## Summary
- expose a new subdomain `boltcipher.f418.me` through Caddy
- document how to run BOLTCipher outside of the compose setup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b2ea84cf88333b446cd37b709721d