### PR TITLE
Update proxy port for BOLTCipher

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ podman compose logs -f
 
 ## BOLTCipher
 
-BOLTCipher is an additional service that currently runs outside of the Compose environment. Start it on the host so that it listens on port `8080`. The Caddy proxy forwards `https://boltcipher.f418.me` to this local service via `host.docker.internal:8080`. No container configuration is required at this time.
+BOLTCipher is an additional service that currently runs outside of the Compose environment. Start it on the host so that it listens on port `8081`. The Caddy proxy forwards `https://boltcipher.f418.me` to this local service. The Compose file maps both `host.docker.internal` and `host.containers.internal` to the host gateway so the container can resolve the address regardless of whether you use Docker or Podman. No additional container configuration is required.
 
  
 

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -22,8 +22,8 @@ f418.me {
 
 boltcipher.f418.me {
     # BOLTCipher runs outside of the compose setup on the host. We forward
-    # requests to the host's port 8080.
-    reverse_proxy host.docker.internal:8080
+    # requests to the host's port 8081.
+    reverse_proxy host.docker.internal:8081
 
     # Compression and basic security headers
     encode gzip

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,9 @@ services:
     environment:
       - ACME_AGREE=true
       - EMAIL=${CADDY_ACME_EMAIL}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+      - "host.containers.internal:host-gateway"
     volumes:
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
       - ./caddy/data:/data


### PR DESCRIPTION
## Summary
- forward boltcipher requests to port 8081
- document the new host port requirement in README

## Testing
- `podman --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b375c11e88333913ba12164655030