### PR TITLE
Fix mixed content for BOLTCipherverifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ in a separate project, but Compose expects it to be available in the
 port `8000`. Caddy forwards `https://boltcipherverifier.f418.me` to this
 container.
 
+When running behind the Caddy reverse proxy, make sure the Uvicorn server is
+started with the `--proxy-headers` option (and `--forwarded-allow-ips=*`) so
+that generated URLs use `https`. Without this, browsers may report *mixed
+content* errors because links to static files are rendered with `http`.
+
  
 
 ## File Overview

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
   boltcipherverifier:
     image: boltcipherverifier
     container_name: boltcipherverifier
+    command: uvicorn main:app --host 0.0.0.0 --port 8000 --proxy-headers --forwarded-allow-ips="*"
     expose:
       - "8000"
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- add proxy headers option to BOLTCipherverifier service
- document the need to enable `--proxy-headers`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c95457dec83338cf01853e949cd16